### PR TITLE
Add some image encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ terms of memory footprint) of the original image on reading.
   (http://www.vips.ecs.soton.ac.uk/index.php?title=Libvips)
 - External command `vipsthumbnail` with parameters `-s 150`
   (http://www.vips.ecs.soton.ac.uk/index.php?title=Libvips)
-- [resize.go](https://code.google.com/p/appengine-go/source/browse/example/moustachio/resize/resize.go)
-  by the Go authors, which performs a Nearest-Neighbor scaling
 
 ### Installation
 
@@ -94,7 +92,6 @@ Ubuntu 14.04. Here are the results:
 | Nfnt_NearestNeighbor  |      3.498s |      0.057% |    X    |
 | imaging_box           |      4.734s |      0.057% |    X    |
 | gift_box              |      4.746s |      0.057% |    X    |
-| moustaschio_resize    |      7.124s |      0.057% |    X    |
 
 
 --------
@@ -105,7 +102,6 @@ Yet another scenario ran by [lazywei](https://github.com/lazywei), 2.5GHz Intel 
 | -------------------- | ----------------------:|
 | magickwand_box       |  155.371531ms          |
 | imaging_Box          |  463.459339ms          |
-| moustaschio_resize   |  719.051885ms          |
 | Nfnt_NearestNeighbor |  1.436507946s          |
 | OpenCv               |   97.353041ms          |
 
@@ -117,7 +113,6 @@ Yet another scenario ran by [bamiaux](https://github.com/bamiaux), 3.3GHz Intel 
 | -------------------- | ----------------------:|
 | rez_bilinear         |  148ms                 |
 | imaging_Box          |  243ms                 |
-| moustaschio_resize   |  407ms                 |
 | Nfnt_NearestNeighbor |  233ms                 |
 
 --------

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ terms of memory footprint) of the original image on reading.
   (http://www.vips.ecs.soton.ac.uk/index.php?title=Libvips)
 - External command `vipsthumbnail` with parameters `-s 150`
   (http://www.vips.ecs.soton.ac.uk/index.php?title=Libvips)
+- External command `epeg` with parameters `-m 150`
+  (https://github.com/mattes/epeg)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ terms of memory footprint) of the original image on reading.
   (http://www.vips.ecs.soton.ac.uk/index.php?title=Libvips)
 - https://github.com/daddye/trez, an image resizer build on top of OpenCV and
   jpeg-turbo
+- https://camlistore.org/pkg/images/fastjpeg, package fastjpeg uses djpeg(1),
+  from the Independent JPEG Group's (www.ijg.org) jpeg package, to quickly
+  down-sample images on load
 - External command `vipsthumbnail` with parameters `-s 150`
   (http://www.vips.ecs.soton.ac.uk/index.php?title=Libvips)
 - External command `epeg` with parameters `-m 150`
@@ -65,7 +68,8 @@ available:
 | `opencv`    | Include `lazywei/go-opencv` in the tests.               |
 | `imagick`   | Include `gographics/imagick` in the tests.              |
 | `vips`      | Include `DAddYE/vips in the tests`.                     |
-| `all`       | An alias for `opencv imagick vips`.                     |
+| `fastjpeg`  | Include `camlistore/fastjpeg in the tests`.             |
+| `all`       | An alias for `opencv imagick fastjpeg vips`.            |
 | `nopure`    | Don't include the Pure Golang packages                  |
 | `noexec`    | Don't run the tests that execute other programs.        |
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ terms of memory footprint) of the original image on reading.
   in these tests
 - https://github.com/DAddYE/vips, bindings for libvips
   (http://www.vips.ecs.soton.ac.uk/index.php?title=Libvips)
+- https://github.com/daddye/trez, an image resizer build on top of OpenCV and
+  jpeg-turbo
 - External command `vipsthumbnail` with parameters `-s 150`
   (http://www.vips.ecs.soton.ac.uk/index.php?title=Libvips)
 - External command `epeg` with parameters `-m 150`

--- a/README.md
+++ b/README.md
@@ -127,6 +127,29 @@ Yet another scenario ran by [bamiaux](https://github.com/bamiaux), 3.3GHz Intel 
 
 --------
 
+A new scenario ran by [nono](https://github.com/nono), 3.4GHz Intel Core i7, Ubuntu 16.10:
+
+| Table                          | Time (file avg.) | Size (file avg.) | Pure Go |
+|--------------------------------|-----------------:|-----------------:|:-------:|
+| ImageMagick_thumbnail          |           0.057s |           0.361% |         |
+| vips                           |           0.070s |           0.260% |         |
+| epeg                           |           0.079s |           0.207% |         |
+| fastjpeg                       |           0.082s |           0.186% |         |
+| opencv                         |           0.110s |           0.597% |         |
+| vipsthumbnail                  |           0.115s |           0.441% |         |
+| GraphicsMagick_thumbnail       |           0.172s |           0.427% |         |
+| magickwand_box                 |           0.190s |           0.575% |         |
+| T-REZ                          |           0.204s |           0.323% |         |
+| rez_bilinear                   |           0.349s |           0.140% |    X    |
+| x_image_draw                   |           0.370s |           0.160% |    X    |
+| imaging_box                    |           0.439s |           0.146% |    X    |
+| gift_box                       |           0.440s |           0.146% |    X    |
+| Nfnt_NearestNeighbor           |           0.447s |           0.146% |    X    |
+| bild_resize                    |           0.515s |           0.206% |    X    |
+| ImageMagick_resize             |           0.568s |           0.542% |         |
+
+--------
+
 So, what is to learn from that? While all of the currently existing
 pure-Go-language solutions do a pretty good job in generating good-looking
 thumbnails, they are much slower than the veteran dedicated image processing

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ are
   algorithms of the package. Here, it's called 'Box'
 - https://github.com/disintegration/imaging Again, I use one of the fastest
   algorithms of the package. Here, it's called 'Box'
+- https://github.com/anthonynsimon/bild A collection of parallel image
+  processing algorithms in pure Go ('NearestNeighbor' algorithm)
 - [ImageMagick convert](http://www.imagemagick.org/script/convert.php) with the options `-resize 150x150>`
 - [ImageMagick convert](http://www.imagemagick.org/script/convert.php) with the
   options `-define "jpeg:size=300x300 -thumbnail 150x150>`. `-thumbnail` is

--- a/exec.go
+++ b/exec.go
@@ -26,6 +26,31 @@ func init() {
 	} else {
 		fmt.Println("Cannot find vipsthumbnail in PATH, will skip VIPS tests")
 	}
+	if _, err := exec.LookPath("epeg"); err == nil {
+		RegisterResizer("epeg", epegThumbnail)
+	} else {
+		fmt.Println("Cannot find epeg in PATH, will skip epeg tests")
+	}
+}
+
+func epegThumbnail(origName, newName string) (int, int64) {
+	origFileStat, _ := os.Stat(origName)
+	var args = []string{
+		"-m", "150",
+		origName,
+		newName,
+	}
+
+	var cmd *exec.Cmd
+	path, _ := exec.LookPath("epeg")
+	cmd = exec.Command(path, args...)
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println(err)
+		return 0, origFileStat.Size()
+	}
+	newFileStat, _ := os.Stat(newName)
+	return int(newFileStat.Size()), origFileStat.Size()
 }
 
 func vipsthumbnail(origName, newName string) (int, int64) {

--- a/fastjpeg.go
+++ b/fastjpeg.go
@@ -1,0 +1,48 @@
+// +build fastjpeg all
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"image/jpeg"
+	"os"
+
+	"camlistore.org/pkg/images/fastjpeg"
+	"camlistore.org/pkg/images/resize"
+)
+
+func init() {
+	if fastjpeg.Available() {
+		RegisterResizer("fastjpeg", resizeFastjpeg)
+	} else {
+		fmt.Println("Cannot find djpeg in PATH, will skip fastjpeg tests")
+	}
+}
+
+func resizeFastjpeg(origName, newName string) (int, int64) {
+	origFile, _ := os.Open(origName)
+	origFileStat, _ := origFile.Stat()
+
+	downsampled, err := fastjpeg.DecodeDownsample(origFile, 8)
+	origFile.Close()
+	if err != nil {
+		fmt.Println(err)
+		return 0, origFileStat.Size()
+	}
+
+	resized := resize.Resize(downsampled, downsampled.Bounds(), 150, 150)
+
+	b := new(bytes.Buffer)
+	jpeg.Encode(b, resized, nil)
+	blen := b.Len()
+	cacheFile, err := os.Create(newName)
+	defer cacheFile.Close()
+	if err != nil {
+		fmt.Println(err)
+		return 0, origFileStat.Size()
+	}
+	b.WriteTo(cacheFile)
+
+	return blen, origFileStat.Size()
+}

--- a/imagick.go
+++ b/imagick.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gographics/imagick/imagick"
+	"gopkg.in/gographics/imagick.v2/imagick"
 )
 
 func init() {

--- a/opencv.go
+++ b/opencv.go
@@ -3,13 +3,17 @@
 package main
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 
+	"github.com/daddye/trez"
 	"github.com/lazywei/go-opencv/opencv"
 )
 
 func init() {
 	RegisterResizer("opencv", resizeOpenCv)
+	RegisterResizer("T-REZ", resizeTRez)
 }
 
 func resizeOpenCv(origName, newName string) (int, int64) {
@@ -25,4 +29,43 @@ func resizeOpenCv(origName, newName string) (int, int64) {
 	newFileStat, _ := os.Stat(newName)
 
 	return int(newFileStat.Size()), origFileStat.Size()
+}
+
+func resizeTRez(origName, newName string) (int, int64) {
+	origFileStat, _ := os.Stat(origName)
+	options := trez.Options{
+		Width:   150,
+		Height:  150,
+		Algo:    trez.FIT,
+		Quality: 95,
+	}
+	origFile, err := os.Open(origName)
+	if err != nil {
+		fmt.Println(err)
+		return 0, origFileStat.Size()
+	}
+	defer origFile.Close()
+	buf, err := ioutil.ReadAll(origFile)
+	if err != nil {
+		fmt.Println(err)
+		return 0, origFileStat.Size()
+	}
+	buf, err = trez.Resize(buf, options)
+	if err != nil {
+		fmt.Println(err)
+		return 0, origFileStat.Size()
+	}
+	cacheFile, err := os.Create(newName)
+	if err != nil {
+		fmt.Println(err)
+		return 0, origFileStat.Size()
+	}
+	defer cacheFile.Close()
+	_, err = cacheFile.Write(buf)
+	if err != nil {
+		fmt.Println(err)
+		return 0, origFileStat.Size()
+	}
+
+	return int(len(buf)), origFileStat.Size()
 }

--- a/pure.go
+++ b/pure.go
@@ -9,7 +9,6 @@ import (
 	"image/jpeg"
 	"os"
 
-	moustaschio_resize "code.google.com/p/appengine-go/example/moustachio/resize"
 	"github.com/bamiaux/rez"
 	"github.com/disintegration/gift"
 	"github.com/disintegration/imaging"
@@ -21,7 +20,6 @@ import (
 func init() {
 	RegisterPureResizer("imaging_box", resizeImaging)
 	RegisterPureResizer("gift_box", resizeGift)
-	RegisterPureResizer("moustaschio_resize", moustachioResize)
 	RegisterPureResizer("Nfnt_NearestNeighbor", resizeNfntNearestNeighbor)
 	RegisterPureResizer("rez_bilinear", resizeRezBilinear)
 	RegisterPureResizer("x_image_draw", resizeXImageDraw)
@@ -100,41 +98,6 @@ func resizeRez(origName, newName string, filter rez.Filter) (int, int64) {
 
 func resizeRezBilinear(origName, newName string) (int, int64) {
 	return resizeRez(origName, newName, rez.NewBilinearFilter())
-}
-
-func moustachioResample(origName, newName string) (int, int64) {
-	return resizeMoustachio(origName, newName, moustaschio_resize.Resample)
-}
-
-func moustachioResize(origName, newName string) (int, int64) {
-	return resizeMoustachio(origName, newName, moustaschio_resize.Resize)
-}
-
-func resizeMoustachio(origName, newName string, method func(image.Image, image.Rectangle, int, int) image.Image) (int, int64) {
-	origFile, _ := os.Open(origName)
-	origImage, _ := jpeg.Decode(origFile)
-	origFileStat, _ := origFile.Stat()
-	origFile.Close()
-
-	var resized image.Image
-	p := origImage.Bounds().Size()
-	if p.X > p.Y {
-		resized = method(origImage, origImage.Bounds(), 150, 100)
-	} else {
-		resized = method(origImage, origImage.Bounds(), 100, 150)
-	}
-	b := new(bytes.Buffer)
-	jpeg.Encode(b, resized, nil)
-	blen := b.Len()
-	cacheFile, err := os.Create(newName)
-	defer cacheFile.Close()
-	if err != nil {
-		fmt.Println(err)
-		return 0, origFileStat.Size()
-	}
-	b.WriteTo(cacheFile)
-
-	return blen, origFileStat.Size()
 }
 
 func resizeImaging(origName, newName string) (int, int64) {


### PR DESCRIPTION
Add some new contenders and make a run on my machine with all the image resizers.

It looks like go has made some progress, but pure go encoders are still several times slower than the faster images encoder.