### PR TITLE
Update x/image to fix TIFF vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fawick/speedtest-resize
 
-go 1.13
+go 1.25.0
 
 require (
 	github.com/anthonynsimon/bild v0.10.0
@@ -8,5 +8,5 @@ require (
 	github.com/disintegration/gift v1.2.1
 	github.com/disintegration/imaging v1.6.1
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
-	golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8
+	golang.org/x/image v0.43.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,6 @@ github.com/disintegration/imaging v1.6.1/go.mod h1:xuIt+sRxDFrHS0drzXUlCJthkJ8k7
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.43.0 h1:FLxcP4ec2350nTfOC8ysKtqYSIFbk/QGjw1ZHNP4tsY=
+golang.org/x/image v0.43.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
## Summary

- update `golang.org/x/image` to `v0.43.0` to fix GHSA-q675-qj96-32m9
- use the first release that also fixes the newer reachable TIFF vulnerabilities GO-2026-5062 and GO-2026-5066
- raise the Go directive to 1.25, as required by the patched module

## Verification

- `go test -mod=readonly ./...`
- `govulncheck ./...` — no vulnerabilities found

Advisory: https://github.com/advisories/GHSA-q675-qj96-32m9