### PR TITLE
Add CI and dependency security automation

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "[resume] Go is unavailable; run .agents/setup to repair the orb" >&2
+  exit 1
+fi
+
+echo "[resume] Orb environment is ready"

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go_version="1.25.12"
+go_archive="go${go_version}.linux-amd64.tar.gz"
+go_checksum="234828b7a89e0e303d2556310ee549fbcf253d28de937bac3da13d6294262ac1"
+install_root="$HOME/.local/share/go/go${go_version}"
+archive_path="$HOME/.cache/amp/toolchains/$go_archive"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "[setup] Installing curl"
+  sudo apt-get update
+  sudo apt-get install -y curl ca-certificates
+fi
+
+started=$SECONDS
+echo "[setup] Ensuring Go ${go_version} is installed"
+if [[ ! -x "$install_root/bin/go" ]] || [[ "$($install_root/bin/go version)" != "go version go${go_version} linux/amd64" ]]; then
+  mkdir -p "$(dirname "$archive_path")" "$(dirname "$install_root")" "$HOME/.local/bin"
+
+  if [[ ! -f "$archive_path" ]] || ! echo "$go_checksum  $archive_path" | sha256sum --check --status; then
+    curl --fail --location --silent --show-error \
+      "https://go.dev/dl/$go_archive" \
+      --output "$archive_path"
+  fi
+  echo "$go_checksum  $archive_path" | sha256sum --check --status
+
+  staging="$(mktemp -d "$(dirname "$install_root")/.go${go_version}.XXXXXX")"
+  trap 'rm -rf "$staging"' EXIT
+  tar -C "$staging" -xzf "$archive_path"
+  rm -rf "$install_root"
+  mv "$staging/go" "$install_root"
+  rmdir "$staging"
+  trap - EXIT
+fi
+
+mkdir -p "$HOME/.local/bin"
+ln -sfn "$install_root/bin/go" "$HOME/.local/bin/go"
+ln -sfn "$install_root/bin/gofmt" "$HOME/.local/bin/gofmt"
+echo "[setup] Go ready in $((SECONDS - started))s"
+
+started=$SECONDS
+echo "[setup] Downloading Go modules"
+"$install_root/bin/go" mod download
+echo "[setup] Go modules ready in $((SECONDS - started))s"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "30 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go test -mod=readonly ./...
+
+  govulncheck:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.mod
+          go-package: ./...

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ terms of memory footprint) of the original image on reading.
 
 ### Installation
 
+The default pure-Go build requires Go 1.25 or newer.
+
 To run the tests `go get` the source and compile/run it:
 
     $ go get -u github.com/fawick/speedtest-resize -tags all


### PR DESCRIPTION
## Summary

- add pull request, push, and weekly CI for tests and `govulncheck`
- configure weekly Dependabot updates for Go modules and GitHub Actions
- document the Go 1.25 minimum version
- add verified Amp orb setup and resume lifecycle scripts

## Verification

- `go test -mod=readonly ./...`
- `govulncheck ./...`
- `actionlint .github/workflows/ci.yml`
- `.agents/setup` run twice; warm runs complete in under one second
- `.agents/resume` completes in under one second